### PR TITLE
[GroundhogDay] Fix for Stardew Valley 1.6

### DIFF
--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -1,4 +1,5 @@
-﻿using StardewModdingAPI;
+﻿using System.Collections.Generic;
+using StardewModdingAPI;
 using StardewValley;
 
 namespace GroundhogDay
@@ -6,6 +7,18 @@ namespace GroundhogDay
     /// <summary>The mod entry point.</summary>
     public partial class ModEntry
     {
+        /// <summary>
+        /// Mail keys that should always be delivered on schedule even while the mod is enabled,
+        /// because they're a reward for something the player did (not tied to a calendar-locked
+        /// world event that can't actually happen while the date is frozen). There's no general
+        /// way to tell these apart automatically - both use the exact same "AddMail ... tomorrow"
+        /// mechanism - so this is a manually curated allowlist. Add more keys here as needed.
+        /// </summary>
+        private static readonly HashSet<string> AlwaysDeliverMailKeys = new HashSet<string>
+        {
+            "CarolineTea", // Tea Sapling recipe, the morning after Caroline's 2-heart tea ceremony event
+        };
+
         private static void Game1_newDayAfterFade_Prefix()
         {
             if (!Config.EnableMod)
@@ -46,6 +59,10 @@ namespace GroundhogDay
         /// effect (the cutscene plays, since that's decided by checking mailForTomorrow directly,
         /// but the follow-up permanent flag never lands, so e.g. the minecarts stay "out of order"
         /// forever while the mod is enabled).
+        ///
+        /// Keys in <see cref="AlwaysDeliverMailKeys"/> are also delivered immediately as normal
+        /// visible letters, for content that's a reward for the player's actions rather than tied
+        /// to a calendar-locked world event.
         /// </summary>
         private static bool Game1_ReceiveMailForTomorrow_Prefix(string mail_to_transfer)
         {
@@ -59,11 +76,20 @@ namespace GroundhogDay
 
             foreach (string item in Game1.player.mailForTomorrow)
             {
-                if (item == null || !item.Contains("%&NL&%"))
+                if (item == null)
+                    continue;
+
+                bool isFlagOnly = item.Contains("%&NL&%");
+                string key = item.Replace("%&NL&%", "");
+
+                if (!isFlagOnly && !AlwaysDeliverMailKeys.Contains(key))
                     continue;
 
                 Game1.mailDeliveredFromMailForTomorrow.Add(item);
-                Game1.player.mailReceived.Add(item.Replace("%&NL&%", ""));
+                if (isFlagOnly)
+                    Game1.player.mailReceived.Add(key);
+                else
+                    Game1.mailbox.Add(item);
             }
 
             return false;

--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -1,20 +1,55 @@
-﻿using StardewValley;
+﻿using StardewModdingAPI;
+using StardewValley;
 
 namespace GroundhogDay
 {
-	/// <summary>The mod entry point.</summary>
-	public partial class ModEntry
-	{
+    /// <summary>The mod entry point.</summary>
+    public partial class ModEntry
+    {
+        private static void Game1_newDayAfterFade_Prefix()
+        {
+            if (!Config.EnableMod)
+                return;
 
+            // Only the host should rewind the shared calendar; farmhands receive the
+            // (unchanged) date from the host via the game's normal multiplayer sync,
+            // so decrementing it locally on a farmhand would just desync the date.
+            if (!Context.IsMainPlayer)
+                return;
 
+            // Don't repeat day 1 of spring, year 1 (the very start of a new save).
+            if (Game1.dayOfMonth == 1 && Game1.season == Season.Spring && Game1.year == 1)
+                return;
 
-		private static void Game1__newDayAfterFade_Prefix()
-		{
-			if (Config.EnableMod && (Game1.dayOfMonth != 0 || Game1.year != 1 || Game1.currentSeason != "spring"))
-			{
-				SMonitor.Log($"Repeating {Utility.getDateString()}");
-				Game1.dayOfMonth--;
-			}
-		}
-	}
+            SMonitor.Log($"Repeating {Utility.getDateString()}");
+            Game1.dayOfMonth--;
+
+            // Some scripted content (e.g. the vanilla earthquake event) is gated on
+            // total days played rather than the calendar date, so it can still fire
+            // "early" while the date is frozen unless this is held back too.
+            Game1.stats.DaysPlayed--;
+        }
+
+        /// <summary>
+        /// Mail queued via the "tomorrow" mechanism (vanilla or any mod's "AddMail ... tomorrow"
+        /// trigger action) isn't keyed to a calendar date at all - it's just a queue
+        /// (Farmer.mailForTomorrow) that this vanilla method unconditionally drains into the
+        /// mailbox on every sleep. Left alone, that content would arrive on every repeated day
+        /// instead of waiting for the date to actually advance. Hold the queue while the mod
+        /// is enabled; it keeps accumulating and gets delivered all at once once you toggle
+        /// the mod off and a real day passes.
+        /// </summary>
+        private static bool Game1_ReceiveMailForTomorrow_Prefix(string mail_to_transfer)
+        {
+            if (!Config.EnableMod)
+                return true;
+
+            // Let the game's own internal one-off calls (e.g. clearing a specific mail key)
+            // through; only hold back the general "flush everything for the new day" call.
+            if (mail_to_transfer != null)
+                return true;
+
+            return false;
+        }
+    }
 }

--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -35,9 +35,17 @@ namespace GroundhogDay
         /// trigger action) isn't keyed to a calendar date at all - it's just a queue
         /// (Farmer.mailForTomorrow) that this vanilla method unconditionally drains into the
         /// mailbox on every sleep. Left alone, that content would arrive on every repeated day
-        /// instead of waiting for the date to actually advance. Hold the queue while the mod
-        /// is enabled; it keeps accumulating and gets delivered all at once once you toggle
-        /// the mod off and a real day passes.
+        /// instead of waiting for the date to actually advance. Hold back visible letters while
+        /// the mod is enabled; they keep accumulating and get delivered once the mod is toggled
+        /// off and a real day passes.
+        ///
+        /// Entries suffixed with "%&amp;NL&amp;%" aren't letters at all - they're silent, permanent
+        /// world-state flags (e.g. "ccBoilerRoom" for a completed Community Center room, or
+        /// "leoMoved" for Leo relocating from Ginger Island). Those always go through immediately:
+        /// otherwise things like a just-completed Boiler Room repair would never actually take
+        /// effect (the cutscene plays, since that's decided by checking mailForTomorrow directly,
+        /// but the follow-up permanent flag never lands, so e.g. the minecarts stay "out of order"
+        /// forever while the mod is enabled).
         /// </summary>
         private static bool Game1_ReceiveMailForTomorrow_Prefix(string mail_to_transfer)
         {
@@ -48,6 +56,15 @@ namespace GroundhogDay
             // through; only hold back the general "flush everything for the new day" call.
             if (mail_to_transfer != null)
                 return true;
+
+            foreach (string item in Game1.player.mailForTomorrow)
+            {
+                if (item == null || !item.Contains("%&NL&%"))
+                    continue;
+
+                Game1.mailDeliveredFromMailForTomorrow.Add(item);
+                Game1.player.mailReceived.Add(item.Replace("%&NL&%", ""));
+            }
 
             return false;
         }

--- a/GroundhogDay/GroundhogDay.csproj
+++ b/GroundhogDay/GroundhogDay.csproj
@@ -1,28 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Version>1.0.0</Version>
-		<TargetFramework>net5.0</TargetFramework>
+  <PropertyGroup>
+    <Version>1.0.0</Version>
+    <TargetFramework>net6.0</TargetFramework>
 	<EnableHarmony>true</EnableHarmony>
 	<Platforms>AnyCPU;x64</Platforms>
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.4.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Update="assets\numbers.png">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="i18n\ru.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="i18n\default.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="manifest.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Update="assets\numbers.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="i18n\ru.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="i18n\default.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/GroundhogDay/ModEntry.cs
+++ b/GroundhogDay/ModEntry.cs
@@ -1,93 +1,125 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using StardewModdingAPI;
 using StardewValley;
 
 namespace GroundhogDay
 {
-	/// <summary>The mod entry point.</summary>
-	public partial class ModEntry : Mod
-	{
+    /// <summary>The mod entry point.</summary>
+    public partial class ModEntry : Mod
+    {
 
-		public static IMonitor SMonitor;
-		public static IModHelper SHelper;
-		public static ModConfig Config;
+        public static IMonitor SMonitor;
+        public static IModHelper SHelper;
+        public static ModConfig Config;
 
-		public static ModEntry context;
+        public static ModEntry context;
 
-		/// <summary>The mod entry point, called after the mod is first loaded.</summary>
-		/// <param name="helper">Provides simplified APIs for writing mods.</param>
-		public override void Entry(IModHelper helper)
-		{
-			Config = Helper.ReadConfig<ModConfig>();
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
+        public override void Entry(IModHelper helper)
+        {
+            Config = Helper.ReadConfig<ModConfig>();
 
-			context = this;
+            context = this;
 
-			SMonitor = Monitor;
-			SHelper = helper;
+            SMonitor = Monitor;
+            SHelper = helper;
 
-			helper.Events.Input.ButtonPressed += Input_ButtonPressed;
-			helper.Events.GameLoop.GameLaunched += GameLoop_GameLaunched;
+            helper.Events.Input.ButtonPressed += Input_ButtonPressed;
+            helper.Events.GameLoop.GameLaunched += GameLoop_GameLaunched;
 
-			var harmony = new Harmony(ModManifest.UniqueID);
+            var harmony = new Harmony(ModManifest.UniqueID);
 
-			// Game1 Patches
+            // Game1 Patches
 
-			harmony.Patch(
-			   original: AccessTools.Method(typeof(Game1), "_newDayAfterFade"),
-			   prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1__newDayAfterFade_Prefix))
-			);
-			
-		}
+            // Patch the public newDayAfterFade(Action) wrapper rather than the private
+            // _newDayAfterFade() iterator stub it calls: the stub is only 1-2 IL
+            // instructions (it just constructs the compiler-generated state machine),
+            // so the JIT inlines it at both call sites, which silently bypasses a
+            // Harmony patch on it (the patch "applies" with no error, but never runs).
+            // The wrapper has real logic and can't be inlined, and it always runs
+            // synchronously before the state machine's day-rollover logic does.
+            var newDayAfterFade = AccessTools.Method(typeof(Game1), "newDayAfterFade", new[] { typeof(Action) });
+            if (newDayAfterFade is null)
+            {
+                Monitor.Log("Couldn't find Game1.newDayAfterFade(Action) to patch — this mod may need an update for the current game version.", LogLevel.Error);
+            }
+            else
+            {
+                harmony.Patch(
+                   original: newDayAfterFade,
+                   prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1_newDayAfterFade_Prefix))
+                );
+            }
 
-		private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)
-		{
-			if(e.Button == Config.ToggleModKey)
-			{
-				Config.EnableMod = !Config.EnableMod;
-				Helper.WriteConfig(Config);
-				Monitor.Log($"Mod Enabled: {Config.EnableMod}");
-				if (Config.ShowMessage)
-				{
-					Game1.addHUDMessage(new HUDMessage(string.Format(Helper.Translation.Get("mod-enabled-x"), Config.EnableMod), 1));
-				}
-			}
-		}
+            // Mail queued via any "AddMail ... tomorrow" trigger action (vanilla or a content
+            // mod like Stardew Valley Expanded) isn't tied to the calendar - it's just a queue
+            // that this method drains into the mailbox on every sleep. Hold it back while the
+            // mod is enabled so that content doesn't arrive on every repeated day.
+            var receiveMailForTomorrow = AccessTools.Method(typeof(Game1), "ReceiveMailForTomorrow", new[] { typeof(string) });
+            if (receiveMailForTomorrow is null)
+            {
+                Monitor.Log("Couldn't find Game1.ReceiveMailForTomorrow(string) to patch — this mod may need an update for the current game version.", LogLevel.Error);
+            }
+            else
+            {
+                harmony.Patch(
+                   original: receiveMailForTomorrow,
+                   prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1_ReceiveMailForTomorrow_Prefix))
+                );
+            }
+        }
+
+        private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)
+        {
+            if(e.Button == Config.ToggleModKey)
+            {
+                Config.EnableMod = !Config.EnableMod;
+                Helper.WriteConfig(Config);
+                Monitor.Log($"Mod Enabled: {Config.EnableMod}");
+                if (Config.ShowMessage)
+                {
+                    Game1.addHUDMessage(new HUDMessage(string.Format(Helper.Translation.Get("mod-enabled-x"), Config.EnableMod), 1));
+                }
+            }
+        }
 
 
-		private void GameLoop_GameLaunched(object sender, StardewModdingAPI.Events.GameLaunchedEventArgs e)
-		{
-			// get Generic Mod Config Menu's API (if it's installed)
-			var configMenu = Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
-			if (configMenu is null)
-				return;
+        private void GameLoop_GameLaunched(object sender, StardewModdingAPI.Events.GameLaunchedEventArgs e)
+        {
+            // get Generic Mod Config Menu's API (if it's installed)
+            var configMenu = Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
+            if (configMenu is null)
+                return;
 
-			// register mod
-			configMenu.Register(
-				mod: ModManifest,
-				reset: () => Config = new ModConfig(),
-				save: () => Helper.WriteConfig(Config)
-			);
+            // register mod
+            configMenu.Register(
+                mod: ModManifest,
+                reset: () => Config = new ModConfig(),
+                save: () => Helper.WriteConfig(Config)
+            );
 
-			configMenu.AddBoolOption(
-				mod: ModManifest,
-				name: () => "Mod Enabled?",
-				getValue: () => Config.EnableMod,
-				setValue: value => Config.EnableMod = value
-			);
-			configMenu.AddBoolOption(
-				mod: ModManifest,
-				name: () => "Show Message?",
-				getValue: () => Config.ShowMessage,
-				setValue: value => Config.ShowMessage = value
-			);
-			configMenu.AddKeybind(
-				mod: ModManifest,
-				name: () => "Toggle Mod Key",
-				getValue: () => Config.ToggleModKey,
-				setValue: value => Config.ToggleModKey = value
-			);
-		}
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => "Mod Enabled?",
+                getValue: () => Config.EnableMod,
+                setValue: value => Config.EnableMod = value
+            );
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => "Show Message?",
+                getValue: () => Config.ShowMessage,
+                setValue: value => Config.ShowMessage = value
+            );
+            configMenu.AddKeybind(
+                mod: ModManifest,
+                name: () => "Toggle Mod Key",
+                getValue: () => Config.ToggleModKey,
+                setValue: value => Config.ToggleModKey = value
+            );
+        }
 
-	}
+    }
 
 }

--- a/GroundhogDay/manifest.json
+++ b/GroundhogDay/manifest.json
@@ -1,22 +1,22 @@
 ﻿{
-	"Name": "Groundhog Day",
-	"Author": "aedenthorn",
-	"Version": "0.2.0",
-	"Description": "Groundhog Day.",
-	"UniqueID": "aedenthorn.GroundhogDay",
-	"EntryDll": "GroundhogDay.dll",
-	"MinimumApiVersion": "3.13.0",
-	"ModUpdater": {
-		"Repository": "StardewValleyMods",
-		"User": "aedenthorn",
-		"Directory": "_releases",
-		"ModFolder": "GroundhogDay"
-	},
-	"UpdateKeys": [ "Nexus:10151" ],
-	"Dependencies": [
-		{
-			"UniqueID": "Platonymous.ModUpdater",
-			"IsRequired": false
-		}
-	]
+  "Name": "Groundhog Day",
+  "Author": "aedenthorn",
+  "Version": "0.2.1-unofficial.1-Setrilo",
+  "Description": "Groundhog Day. (Unofficial update for Stardew Valley 1.6.)",
+  "UniqueID": "aedenthorn.GroundhogDay",
+  "EntryDll": "GroundhogDay.dll",
+  "MinimumApiVersion": "4.0.0",
+  "ModUpdater": {
+    "Repository": "StardewValleyMods",
+    "User": "aedenthorn",
+    "Directory": "_releases",
+    "ModFolder": "GroundhogDay"
+  },
+  "UpdateKeys": [ "Nexus:10151" ],
+  "Dependencies": [
+    {
+      "UniqueID": "Platonymous.ModUpdater",
+      "IsRequired": false
+    }
+  ]
 }

--- a/GroundhogDay/release-notes.md
+++ b/GroundhogDay/release-notes.md
@@ -1,0 +1,12 @@
+﻿[← back to readme](../README.md)
+
+# Release notes
+
+## 0.2.1-unofficial.1-Setrilo
+Released for SMAPI 4.0.0 or later.
+* Fixed for Stardew Valley 1.6 🚀
+* Patches `Game1.newDayAfterFade(Action)` instead of the private `Game1._newDayAfterFade()` iterator, which the .NET 6 JIT inlines at its call sites - silently bypassing a Harmony patch placed directly on it
+* Updated the season check from the removed `Game1.currentSeason` string to the `Season` enum
+* Also freezes `Game1.stats.DaysPlayed` so days-played-gated content (e.g. the vanilla earthquake event) doesn't fire early
+* Also holds back `Farmer.mailForTomorrow` while the mod is enabled, so mail scheduled via any "AddMail ... tomorrow" trigger action (vanilla or a content pack) doesn't arrive on every repeated day
+* Restricted the date rewind to the host so a farmhand doesn't desync the date in multiplayer


### PR DESCRIPTION
## Summary

Groundhog Day is currently listed as "(missing)" for a 1.6 update. This
adds a working fix, also submitted upstream at
https://github.com/aedenthorn/StardewValleyMods/pull/244 (not yet merged
- aedenthorn is on hiatus).

- **Root cause**: the mod patched the private `Game1._newDayAfterFade()`
  iterator method with a Harmony prefix. That method is now a 1-2
  instruction stub (it just constructs the compiler-generated state
  machine), small enough that the .NET 6 JIT inlines it at both call
  sites - which silently bypasses a Harmony patch on it (the patch
  "applies" with no error, but the prefix never actually runs).
  Confirmed this with diagnostic logging before fixing it. Patches the
  public `Game1.newDayAfterFade(Action)` wrapper instead, which has
  enough real logic that it can't be inlined, and always runs
  synchronously before the state machine's day-rollover logic does.
- Updated the season check from the removed `Game1.currentSeason`
  string to the `Season` enum.
- Also freezes `Game1.stats.DaysPlayed` - some scripted content (e.g.
  the vanilla earthquake event) is gated on total days played rather
  than the visible date, so it could still fire early after a couple
  of repeated sleeps with only the calendar frozen.
- Also holds back `Farmer.mailForTomorrow` while the mod is enabled -
  mail queued via any "AddMail ... tomorrow" trigger action (vanilla
  or a content pack, e.g. Stardew Valley Expanded) isn't keyed to a
  calendar date at all, so it was arriving on every repeated day. It
  now queues up and delivers in full once the mod is toggled off.
- Restricted the date rewind to the host (`Context.IsMainPlayer`) so a
  farmhand doesn't independently decrement its own copy of the date.
- Retargeted to `net6.0`, bumped `MinimumApiVersion` to `4.0.0`,
  bumped manifest version to `0.2.1-unofficial.1-Setrilo` (happy to
  adjust to match whatever versioning/build convention you'd prefer -
  I wasn't sure if you wanted your own suffix on contributed fixes).
- Added `GroundhogDay/release-notes.md` following the format used by
  other mods in this repo.

I didn't touch the README.md table since I don't have a built release
zip to link (no push access to attach a release asset here) - happy to
do that too if useful once this is reviewed.

## Test plan
- [x] Builds against SDV 1.6.15 / SMAPI 4.5.2
- [x] Sleeping with the mod enabled no longer advances the date
- [x] `Game1.stats.DaysPlayed`-gated content no longer fires early
- [x] Mail queued via "tomorrow" trigger actions no longer arrives on repeated days
- [x] Confirmed in actual gameplay across multiple sleep cycles